### PR TITLE
Chapter 8 small error

### DIFF
--- a/Chp 8/8-2_least_square_reg/8-2_least_square_reg.tex
+++ b/Chp 8/8-2_least_square_reg/8-2_least_square_reg.tex
@@ -513,7 +513,7 @@ $\:$ \\
 
 \pause
 
-\item For the model we've been working with, $R^2 = -0.62^2 = 0.38$.
+\item For the model we've been working with, $R^2 = (-0.75)^2 = 0.56$.
 
 \end{itemize}
 
@@ -524,18 +524,18 @@ $\:$ \\
 \begin{frame}
 \frametitle{Interpretation of $R^2$}
 
-\pq{{\small Which of the below is the correct interpretation of $R = -0.62$, $R^2 = 0.38$?}}
+\pq{{\small Which of the below is the correct interpretation of $R = -0.75$, $R^2 = 0.56$?}}
 
 \twocol{0.65}{0.35}{
 \begin{enumerate}[(a)]
 
-\item 38\% of the variability in the \% of HG graduates among the 51 states is explained by the model.
+\item 56\% of the variability in the \% of HG graduates among the 51 states is explained by the model.
 
-\solnMult{ 38\% of the variability in the \% of residents living in poverty among the 51 states is explained by the model.}
+\solnMult{ 56\% of the variability in the \% of residents living in poverty among the 51 states is explained by the model.}
 
-\item 38\% of the time \% HS graduates predict \% living in poverty correctly.
+\item 56\% of the time \% HS graduates predict \% living in poverty correctly.
 
-\item 62\% of the variability in the \% of residents living in poverty among the 51 states is explained by the model.
+\item 75\% of the variability in the \% of residents living in poverty among the 51 states is explained by the model.
 
 \end{enumerate}
 }{


### PR DESCRIPTION
Fixed error on p.33f of Ch 8 referring to previous example. Slope (-0.62) was used instead of R value (-0.75). Also, it is standard to use parenthesis for something like (-0.75)^2.